### PR TITLE
Update LIGO images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -59,7 +59,8 @@ biocontainers/blast
 cyverse/rsem-prepare
 
 # LIGO worker node
-ligo/ligo-wn
+ligo/software:jessie
+ligo/software:jessie-proposed
 
 # LIGO PyCBC compute nodes
 pycbc/pycbc-el7:v*


### PR DESCRIPTION
My goal is to retire`ligo/ligo-wn` in favor of `ligo/software`. Options in my order of preference:

1. Freeze `ligo-wn:latest` as it currently stands and tell people who are using it to move by X/Y/2017.
1. Make `/cvmfs/singularity.opensciencegrid.org/ligo/ligo-wn:latest` a symbolic link to `/cvmfs/singularity.opensciencegrid.org/ligo/software:jessie`.

Please do not merge unless you are confident that you can keep `ligo-wn` working in one of these capacities. I think the user base is presently 0, but I'd rather operate on assumption that it's being used and plan a proper transition.